### PR TITLE
slide 02 math_recap_linear_algebra correction

### DIFF
--- a/AA2223/course/02_math_recap_linear_algebra/02_math_recap_linear_algebra.ipynb
+++ b/AA2223/course/02_math_recap_linear_algebra/02_math_recap_linear_algebra.ipynb
@@ -996,7 +996,7 @@
     "$$ \\mathbf{x} \\in \\mathbb{R}^D, \\mathbf{y} \\in \\mathbb{R}^P $$\n",
     "\n",
     "\\begin{equation}\n",
-    "\\mathbf{x} \\mathbf{y}^T \\neq \\mathbf{y} \\mathbf{x}^T\n",
+    "\\mathbf{x} \\mathbf{y}^T \\neq \\mathbf{y}^T \\mathbf{x}\n",
     "\\end{equation}\n",
     "\n",
     "\n",


### PR DESCRIPTION
1. Outer product x⋅yˆT ≠ y⋅x^T is wrong , correction x⋅yˆT ≠ y^T⋅x

given x and y both with shape 3x1 , transpose vector 1x3.  Error : x⋅yˆT = y⋅x^T --> 3x1 ⋅ 1x3 = 3x1 ⋅ 1x3 --> 3x3 . both sides give a matrix , in the left side instead of having x^T is should be y^T  satisfy that is not commutative