### PR TITLE
Fixed KaTeX erros and some typos

### DIFF
--- a/AA2223/course/03_math_recap_eig_pca_3dmm/03_math_recap_eig_pca_3dmm.ipynb
+++ b/AA2223/course/03_math_recap_eig_pca_3dmm/03_math_recap_eig_pca_3dmm.ipynb
@@ -3197,7 +3197,7 @@
    "source": [
     "# 3D Face modeling with PCA\n",
     "\n",
-    "$$ \\mbf{S}^{\\prime} = \\mbf{\\hat{S}} + \\sum_{i}^{M-1} \\alpha_i \\mbf{U}_i $$ where:\n",
+    "$ \\mbf{S}^{\\prime} = \\mbf{\\hat{S}} + \\sum_{i}^{M-1} \\alpha_i \\mbf{U}_i $ where:\n",
     "- $ \\mbf{\\hat{S}} $ is the mean shape\n",
     "- and $\\mbf{U}_i$ are the $M-1$ principal components that you can compute by learning PCA on $\\mbf{X}=\\{\\mbf{S}_i\\}_{i=1}^M$"
    ]
@@ -3230,13 +3230,13 @@
    "source": [
     "# 3D Face modeling with PCA\n",
     "\n",
-    "$$ \\mbf{S}^{\\prime} = \\mbf{\\hat{S}} + \\sum_{i}^{M-1} \\alpha_i \\mbf{U}_i $$ where:\n",
+    "$ \\mbf{S}^{\\prime} = \\mbf{\\hat{S}} + \\sum_{i}^{M-1} \\alpha_i \\mbf{U}_i $ where:\n",
     "\n",
     "PCA assumes the data generation process is a **multivariate Gaussian distribution (i.e. a Gaussian/Normal distribution but in 3N-D).**\n",
     "\n",
-    "$$\n",
+    "$\n",
     " \\underbrace{\\{\\mathbf{S}_i\\}_{i=1}^M}_{\\text{known}}  \\sim \\underbrace{\\mathcal{N}(\\mbf{\\hat{S}},\\mbf{Cov}_S)}_{\\text{multivariate Gaussian assumption}} \\approx \\underbrace{\\mathcal{D}}_{\\text{unknown}}\n",
-    "$$"
+    "$"
    ]
   },
   {
@@ -3324,7 +3324,7 @@
    "source": [
     "# Expressiveness\n",
     "\n",
-    "$$\\mbf{S}^{\\prime} = \\mbf{\\hat{S}} + \\sum_{i}^{M-1} \\alpha_i \\mbf{U}_i$$ where:\n",
+    "$\\mbf{S}^{\\prime} = \\mbf{\\hat{S}} + \\sum_{i}^{M-1} \\alpha_i \\mbf{U}_i$ where:\n",
     "- $ \\mbf{\\hat{S}} $ is the mean shape\n",
     "- and $\\mbf{U}_i$ are the $ M-1 $ principal components that you can compute by learning PCA on $\\mbf{X}=\\{\\mbf{S}_i\\}_{i=1}^M$."
    ]


### PR DESCRIPTION
Fixed
2 KaTeX parse errors in 03_math_recap_eig_pca_3dmm.ipynb 3D face modelling with pca
Expressiveness equation

Couple of typos in 04_pca_svd_high_dim/04_pca_svd_high_dim.ipynb