### PR TITLE
Update 07_clustering_GMM.ipynb

### DIFF
--- a/AA2223/course/07_clustering_GMM/07_clustering_GMM.ipynb
+++ b/AA2223/course/07_clustering_GMM/07_clustering_GMM.ipynb
@@ -1665,7 +1665,7 @@
    "source": [
     "# Maximization Step\n",
     "$$\n",
-    "-\\sum_{n=1}^{N} \\underbrace{\\frac{\\pi_{k} \\mathcal{N}\\left(\\mathbf{x}^{(n)} \\mid \\mu_{k}, \\Sigma_{k}\\right)}{\\sum_{j=1}^{K} \\pi_{j} \\mathcal{N}\\left(\\mathbf{x} \\mid \\mu_{j}, \\Sigma_{j}\\right)}}_{\\gamma_{nk}}\\Sigma_{k}\\left(\\mathbf{x}^{(n)}-\\mu_{k}\\right) = 0\n",
+    "-\\sum_{n=1}^{N} \\underbrace{\\frac{\\pi_{k} \\mathcal{N}\\left(\\mathbf{x}^{(n)} \\mid \\mu_{k}, \\Sigma_{k}\\right)}{\\sum_{j=1}^{K} \\pi_{j} \\mathcal{N}\\left(\\mathbf{x} \\mid \\mu_{j}, \\Sigma_{j}\\right)}}_{\\gamma_{nk}}\\Sigma_{k}^{-1}\\left(\\mathbf{x}^{(n)}-\\mu_{k}\\right) = 0\n",
     "$$\n",
     "- We used:\n",
     "$$\n",


### PR DESCRIPTION
Missing ^-1 in the Covariance Matrix 
\\Sigma_{k}^{-1} -> \\Sigma_{k}